### PR TITLE
Use ActiveSupport::ReplicationCoordinator to implement active/passive behavior

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Specify your gem's dependencies in solid_queue.gemspec.
 gemspec
+
+gem "rails", github: "basecamp/rails", branch: "flavorjones/replication-coordinator"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,104 @@
+GIT
+  remote: https://github.com/basecamp/rails.git
+  revision: 25ccac9fbd311d172db02f0e4a0be433763f4d24
+  branch: flavorjones/replication-coordinator
+  specs:
+    actioncable (8.2.0.alpha)
+      actionpack (= 8.2.0.alpha)
+      activesupport (= 8.2.0.alpha)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+      zeitwerk (~> 2.6)
+    actionmailbox (8.2.0.alpha)
+      actionpack (= 8.2.0.alpha)
+      activejob (= 8.2.0.alpha)
+      activerecord (= 8.2.0.alpha)
+      activestorage (= 8.2.0.alpha)
+      activesupport (= 8.2.0.alpha)
+      mail (>= 2.8.0)
+    actionmailer (8.2.0.alpha)
+      actionpack (= 8.2.0.alpha)
+      actionview (= 8.2.0.alpha)
+      activejob (= 8.2.0.alpha)
+      activesupport (= 8.2.0.alpha)
+      mail (>= 2.8.0)
+      rails-dom-testing (~> 2.2)
+    actionpack (8.2.0.alpha)
+      actionview (= 8.2.0.alpha)
+      activesupport (= 8.2.0.alpha)
+      nokogiri (>= 1.8.5)
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+      useragent (~> 0.16)
+    actiontext (8.2.0.alpha)
+      action_text-trix (~> 2.1.15)
+      actionpack (= 8.2.0.alpha)
+      activerecord (= 8.2.0.alpha)
+      activestorage (= 8.2.0.alpha)
+      activesupport (= 8.2.0.alpha)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (8.2.0.alpha)
+      activesupport (= 8.2.0.alpha)
+      builder (~> 3.1)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    activejob (8.2.0.alpha)
+      activesupport (= 8.2.0.alpha)
+      globalid (>= 0.3.6)
+    activemodel (8.2.0.alpha)
+      activesupport (= 8.2.0.alpha)
+    activerecord (8.2.0.alpha)
+      activemodel (= 8.2.0.alpha)
+      activesupport (= 8.2.0.alpha)
+      timeout (>= 0.4.0)
+    activestorage (8.2.0.alpha)
+      actionpack (= 8.2.0.alpha)
+      activejob (= 8.2.0.alpha)
+      activerecord (= 8.2.0.alpha)
+      activesupport (= 8.2.0.alpha)
+      marcel (~> 1.0)
+    activesupport (8.2.0.alpha)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    rails (8.2.0.alpha)
+      actioncable (= 8.2.0.alpha)
+      actionmailbox (= 8.2.0.alpha)
+      actionmailer (= 8.2.0.alpha)
+      actionpack (= 8.2.0.alpha)
+      actiontext (= 8.2.0.alpha)
+      actionview (= 8.2.0.alpha)
+      activejob (= 8.2.0.alpha)
+      activemodel (= 8.2.0.alpha)
+      activerecord (= 8.2.0.alpha)
+      activestorage (= 8.2.0.alpha)
+      activesupport (= 8.2.0.alpha)
+      bundler (>= 1.15.0)
+      railties (= 8.2.0.alpha)
+    railties (8.2.0.alpha)
+      actionpack (= 8.2.0.alpha)
+      activesupport (= 8.2.0.alpha)
+      irb (~> 1.13)
+      rackup (>= 1.0.0)
+      rake (>= 12.2)
+      thor (~> 1.0, >= 1.2.2)
+      tsort (>= 0.2)
+      zeitwerk (~> 2.6)
+
 PATH
   remote: .
   specs:
@@ -12,51 +113,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (7.1.5.1)
-      actionview (= 7.1.5.1)
-      activesupport (= 7.1.5.1)
-      nokogiri (>= 1.8.5)
-      racc
-      rack (>= 2.2.4)
-      rack-session (>= 1.0.1)
-      rack-test (>= 0.6.3)
-      rails-dom-testing (~> 2.2)
-      rails-html-sanitizer (~> 1.6)
-    actionview (7.1.5.1)
-      activesupport (= 7.1.5.1)
-      builder (~> 3.1)
-      erubi (~> 1.11)
-      rails-dom-testing (~> 2.2)
-      rails-html-sanitizer (~> 1.6)
-    activejob (7.1.5.1)
-      activesupport (= 7.1.5.1)
-      globalid (>= 0.3.6)
-    activemodel (7.1.5.1)
-      activesupport (= 7.1.5.1)
-    activerecord (7.1.5.1)
-      activemodel (= 7.1.5.1)
-      activesupport (= 7.1.5.1)
-      timeout (>= 0.4.0)
-    activesupport (7.1.5.1)
-      base64
-      benchmark (>= 0.3)
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      connection_pool (>= 2.2.5)
-      drb
-      i18n (>= 1.6, < 2)
-      logger (>= 1.4.2)
-      minitest (>= 5.1)
-      mutex_m
-      securerandom (>= 0.3)
-      tzinfo (~> 2.0)
+    action_text-trix (2.1.15)
+      railties
     appraisal (2.5.0)
       bundler
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
     base64 (0.2.0)
-    benchmark (0.4.0)
     bigdecimal (3.1.9)
     builder (3.3.0)
     concurrent-ruby (1.3.4)
@@ -87,11 +151,26 @@ GEM
     loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    mail (2.8.1)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.1.0)
+    mini_mime (1.1.5)
     minitest (5.25.4)
     mocha (2.1.0)
       ruby2_keywords (>= 0.0.5)
-    mutex_m (0.3.0)
     mysql2 (0.5.6)
+    net-imap (0.5.12)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-smtp (0.5.1)
+      net-protocol
     nio4r (2.7.4)
     nokogiri (1.18.0-aarch64-linux-gnu)
       racc (~> 1.4)
@@ -127,14 +206,6 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
-    railties (7.1.5.1)
-      actionpack (= 7.1.5.1)
-      activesupport (= 7.1.5.1)
-      irb
-      rackup (>= 1.0.0)
-      rake (>= 12.2)
-      thor (~> 1.0, >= 1.2.2)
-      zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
     rdoc (6.8.1)
@@ -180,11 +251,18 @@ GEM
     stringio (3.1.2)
     thor (1.3.2)
     timeout (0.4.3)
+    tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.3)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uri (1.0.4)
+    useragent (0.16.11)
+    websocket-driver (0.8.0)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
     zeitwerk (2.6.0)
 
 PLATFORMS
@@ -204,6 +282,7 @@ DEPENDENCIES
   mysql2
   pg
   puma (~> 7.0)
+  rails!
   rdoc
   rubocop-rails-omakase
   solid_queue!

--- a/lib/solid_queue/processes/standby.rb
+++ b/lib/solid_queue/processes/standby.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module SolidQueue::Processes
+  module Standby
+    extend ActiveSupport::Concern
+
+    delegate :on_active_zone, to: :replication_coordinator
+    delegate :on_passive_zone, to: :replication_coordinator
+    delegate :active_zone?, to: :replication_coordinator
+
+    def replication_coordinator
+      Rails.application.config.replication_coordinator
+    end
+
+    included do
+      on_start { |process| process.replication_coordinator.start_monitoring }
+      on_stop { |process| process.replication_coordinator.stop_monitoring }
+    end
+  end
+end

--- a/lib/solid_queue/scheduler.rb
+++ b/lib/solid_queue/scheduler.rb
@@ -4,11 +4,15 @@ module SolidQueue
   class Scheduler < Processes::Base
     include Processes::Runnable
     include LifecycleHooks
+    include Processes::Standby
 
     attr_reader :recurring_schedule
 
     after_boot :run_start_hooks
-    after_boot :schedule_recurring_tasks
+    after_boot do
+      on_active_zone { schedule_recurring_tasks }
+      on_passive_zone { unschedule_recurring_tasks }
+    end
     before_shutdown :unschedule_recurring_tasks
     before_shutdown :run_stop_hooks
     after_shutdown :run_exit_hooks

--- a/lib/solid_queue/worker.rb
+++ b/lib/solid_queue/worker.rb
@@ -3,8 +3,10 @@
 module SolidQueue
   class Worker < Processes::Poller
     include LifecycleHooks
+    include Processes::Standby
 
     after_boot :run_start_hooks
+    after_boot { on_active_zone { wake_up } }
     before_shutdown :run_stop_hooks
     after_shutdown :run_exit_hooks
 
@@ -27,9 +29,13 @@ module SolidQueue
 
     private
       def poll
-        post_executions
+        if active_zone?
+          post_executions
 
-        pool.idle? ? polling_interval : 10.minutes
+          pool.idle? ? polling_interval : 10.minutes
+        else
+          replication_coordinator.polling_interval
+        end
       end
 
       def post_executions

--- a/lib/solid_queue/worker.rb
+++ b/lib/solid_queue/worker.rb
@@ -27,12 +27,16 @@ module SolidQueue
 
     private
       def poll
+        post_executions
+
+        pool.idle? ? polling_interval : 10.minutes
+      end
+
+      def post_executions
         claim_executions.then do |executions|
           executions.each do |execution|
             pool.post(execution)
           end
-
-          pool.idle? ? polling_interval : 10.minutes
         end
       end
 


### PR DESCRIPTION
This is a draft PR to solicit feedback, see related https://github.com/basecamp/rails/pull/35

---

Worker, Scheduler, and Dispatcher now respect active zone

Note that this pins Rails to a version with ActiveSupport::ReplicationCoordinator
